### PR TITLE
About page css fix

### DIFF
--- a/glri-afinch-web/src/main/webapp/css/custom.css
+++ b/glri-afinch-web/src/main/webapp/css/custom.css
@@ -108,7 +108,7 @@ body.x-body-masked .x-window-plain .x-window-mc { background-color: #dfe8f6 !imp
 
 #ext-gen30{
     padding:0 15px 15px 15px;
-    height:1230px !important;
+    height:100% !important;
 }
 
 #ext-gen30 img{


### PR DESCRIPTION
Should avoid content being cut off on the about page